### PR TITLE
Update file paths in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ The OVB environment files expect:
 
 ::
 
-  cd ~/ovb-lab-freeipa/openstack-virtual-baremetal/
-  bash ~/ovb-lab-freeipa/openstack-virtual-baremetal/deploy_ovb.sh
+  cd ~/ovb-lab-freeipa/ooo-tls-everywhere/
+  bash ovb/deploy_ovb.sh
 
 


### PR DESCRIPTION
This commit updates the location of deploy_ovb.sh in README.rst to point
to the location in this repository instead of the OVB repository.